### PR TITLE
Add read-only dashboard authentication and console user management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,116 @@
-# FCI
+# FCI - Panel del Fondo Común de Inversión
+
+Este proyecto ofrece dos herramientas complementarias:
+
+* **`main.py`**: panel web construido con Streamlit para consultar la
+  información del fondo en modo **solo lectura**. Cada usuario debe iniciar sesión
+  y solo ve los clientes que tenga asociados.
+* **`admin_console.py`**: consola interactiva para administrar los datos del
+  fondo (clientes, movimientos, composición) y gestionar los usuarios que pueden
+  ingresar al panel web.
+
+## Requisitos
+
+* Python 3.8 o superior
+* Dependencias listadas en `requirements.txt`
+
+Instalación rápida de dependencias:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Uso del panel web
+
+Desde la carpeta del proyecto (`cd FCI`):
+
+```bash
+streamlit run main.py
+```
+
+Al ingresar se solicitará usuario y contraseña. Los datos visibles dependen del
+rol asignado en la consola:
+
+* **admin**: puede ver la información completa del fondo (aunque no puede editar
+  desde la web).
+* **cliente**: visualiza únicamente la información de los clientes asociados.
+
+Todas las pestañas (resumen, clientes, gráficos, historial y composición)
+aparecen en modo lectura. Para modificar datos es obligatorio utilizar la
+consola de administración.
+
+## Administración desde la consola
+
+```bash
+python admin_console.py
+```
+
+Desde el menú interactivo se pueden:
+
+1. Consultar el estado general del fondo.
+2. Actualizar el balance diario.
+3. Agregar clientes y registrar suscripciones o rescates.
+4. Cargar la composición del fondo.
+5. **Gestionar usuarios del panel web** (crear, listar, cambiar contraseña o
+   actualizar los clientes asociados).
+
+También existen argumentos de línea de comandos para automatizar tareas. Algunos
+ ejemplos:
+
+```bash
+# Crear un cliente con saldo inicial
+python admin_console.py --cliente "Nuevo Cliente" --saldo 100000
+
+# Registrar una suscripción
+python admin_console.py --suscripcion "Enzo" 5000
+
+# Crear un usuario web asociado a un cliente
+python admin_console.py --crear-usuario juan --clientes-usuario "Juan Perez" \
+    --rol cliente
+
+# Restablecer contraseña de un usuario existente
+python admin_console.py --reset-password juan
+
+# Listar usuarios registrados
+python admin_console.py --listar-usuarios
+```
+
+> **Nota:** si no se indica la contraseña mediante `--password`, la consola la
+> solicitará de forma interactiva para evitar que quede registrada en el
+> historial.
+
+## Usuarios de ejemplo
+
+El archivo `fondo_datos.json` incluye usuarios iniciales a modo de ejemplo. Se
+recomienda reemplazar sus contraseñas mediante la consola antes de usar el
+sistema en producción.
+
+| Usuario  | Rol       | Contraseña | Clientes visibles |
+|----------|-----------|------------|-------------------|
+| `admin`  | admin     | `admin123` | Todos             |
+| `enzo`   | cliente   | `enzo2024` | Enzo              |
+| `roberto`| cliente   | `roberto2024` | Roberto        |
+
+## Estructura de datos
+
+La información del fondo se almacena en `fondo_datos.json`. Las claves más
+importantes son:
+
+* `clientes`: detalle de cuotapartes por inversor.
+* `transacciones`: historial de suscripciones y rescates.
+* `balance_diario`: evolución del balance total del fondo.
+* `composicion_fondo`: instrumentos que componen el fondo con montos y
+  porcentajes.
+* `usuarios`: credenciales y permisos para acceder al panel web.
+
+Todos los cambios realizados desde la consola se guardan automáticamente en este
+archivo.
+
+## Seguridad
+
+* Las contraseñas nunca se almacenan en texto plano, sino como hashes PBKDF2
+  con una sal aleatoria.
+* El panel web no ofrece controles para editar datos; todas las acciones de
+  administración pasan por `admin_console.py`.
+* Ante cualquier inconveniente con el acceso web, se puede restablecer la
+  contraseña de un usuario desde la consola.

--- a/fondo_datos.json
+++ b/fondo_datos.json
@@ -85,5 +85,29 @@
       "porcentaje": 0.09237808796372404
     }
   },
-  "distribucion_activos": {}
+  "distribucion_activos": {},
+  "usuarios": {
+    "admin": {
+      "rol": "admin",
+      "salt": "d6abee56a2b088c492d08bdf34202622",
+      "password_hash": "a1c473767bc2c08fc59920d3bec68886cda1477f3fd6252e118b56b7f2e84484",
+      "clientes": []
+    },
+    "enzo": {
+      "rol": "cliente",
+      "salt": "73dd6adf9677284a6f543c3b41284de3",
+      "password_hash": "56c2e48c790658efc983c01e76251e316afc2fcd30bb93c0615596be88063656",
+      "clientes": [
+        "Enzo"
+      ]
+    },
+    "roberto": {
+      "rol": "cliente",
+      "salt": "2b52bbaf40afe26a16ff921fb09699c3",
+      "password_hash": "1f407c8235d01ac19e1f821b780aa66e2bb813d1fa5a3ad71fd6ce2b425a6f7f",
+      "clientes": [
+        "Roberto"
+      ]
+    }
+  }
 }

--- a/security.py
+++ b/security.py
@@ -1,0 +1,36 @@
+"""Utility functions for password hashing and verification."""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+
+
+def generate_salt() -> str:
+    """Return a random salt encoded as hexadecimal string."""
+    return secrets.token_hex(16)
+
+
+def hash_password(password: str, salt: str) -> str:
+    """Hash ``password`` with the provided hexadecimal ``salt``.
+
+    The function uses PBKDF2-HMAC with SHA-256 to derive the key. The
+    resulting hash is returned as a hexadecimal string so it can be stored in
+    JSON files easily.
+    """
+    return hashlib.pbkdf2_hmac(
+        "sha256",
+        password.encode("utf-8"),
+        bytes.fromhex(salt),
+        100_000,
+    ).hex()
+
+
+def verify_password(password: str, salt: str, password_hash: str) -> bool:
+    """Check whether ``password`` matches ``password_hash`` using ``salt``."""
+    if not salt or not password_hash:
+        return False
+    return hash_password(password, salt) == password_hash
+
+
+__all__ = ["generate_salt", "hash_password", "verify_password"]


### PR DESCRIPTION
## Summary
- add reusable PBKDF2 helpers for storing hashed user credentials
- require Streamlit login and present a read-only dashboard filtered to each user
- extend the administration console with user management commands and update docs/data

## Testing
- python -m compileall FCI

------
https://chatgpt.com/codex/tasks/task_e_68c899686b6883249659d7f50c1ca7f4