### PR TITLE
Add exchange rate handling to dashboard and admin console

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,10 @@ Desde el menú interactivo se pueden:
 1. Consultar el estado general del fondo.
 2. Actualizar el balance diario.
 3. Agregar clientes y registrar suscripciones o rescates.
-4. Cargar la composición del fondo.
+4. Cargar la composición del fondo (acepta montos en pesos y en USD).
 5. **Gestionar usuarios del panel web** (crear, listar, cambiar contraseña o
    actualizar los clientes asociados).
+6. Actualizar el tipo de cambio USD/ARS utilizado para las valuaciones.
 
 También existen argumentos de línea de comandos para automatizar tareas. Algunos
  ejemplos:
@@ -63,6 +64,12 @@ python admin_console.py --cliente "Nuevo Cliente" --saldo 100000
 
 # Registrar una suscripción
 python admin_console.py --suscripcion "Enzo" 5000
+
+# Actualizar el tipo de cambio (pesos por dólar)
+python admin_console.py --tipo-cambio 1000
+
+# Cargar una composición con instrumentos en pesos y dólares
+python admin_console.py --composicion "Pesos:1000000,Dólar liquidez:5000:USD"
 
 # Crear un usuario web asociado a un cliente
 python admin_console.py --crear-usuario juan --clientes-usuario "Juan Perez" \
@@ -100,7 +107,10 @@ importantes son:
 * `transacciones`: historial de suscripciones y rescates.
 * `balance_diario`: evolución del balance total del fondo.
 * `composicion_fondo`: instrumentos que componen el fondo con montos y
-  porcentajes.
+  porcentajes. Cada instrumento puede incluir la moneda original (`moneda`) y
+  el monto en esa divisa (`monto_moneda`).
+* `tipo_cambio`: valor del dólar (ARS/USD) utilizado para convertir las
+  posiciones en moneda extranjera.
 * `usuarios`: credenciales y permisos para acceder al panel web.
 
 Todos los cambios realizados desde la consola se guardan automáticamente en este

--- a/fondo_datos.json
+++ b/fondo_datos.json
@@ -67,22 +67,28 @@
   ],
   "valor_cuotaparte": 1022.4417730177142,
   "total_cuotapartes": 35736.020342908036,
+  "tipo_cambio": 1000.0,
   "composicion_fondo": {
     "Dólar": {
-      "monto": 16987.0,
-      "porcentaje": 0.06538444084332419
+      "monto": 16987000.0,
+      "porcentaje": 39.55045610963395,
+      "moneda": "USD",
+      "monto_moneda": 16987.0
     },
     "JD": {
       "monto": 994400.0,
-      "porcentaje": 3.827532111296966
+      "porcentaje": 2.3152395099440746,
+      "moneda": "ARS"
     },
     "Pesos": {
       "monto": 24944800.0,
-      "porcentaje": 96.01470535989598
+      "porcentaje": 58.078425711638126,
+      "moneda": "ARS"
     },
     "Opciones Galicia": {
       "monto": 24000.0,
-      "porcentaje": 0.09237808796372404
+      "porcentaje": 0.05587866878384734,
+      "moneda": "ARS"
     }
   },
   "distribucion_activos": {},


### PR DESCRIPTION
## Summary
- add exchange rate storage and valuation helpers to the dashboard, including USD metrics and currency-aware composition views
- extend the admin console to capture the USD/ARS rate, accept composition entries in foreign currency, and document the new workflow
- update the sample data with exchange rate metadata so peso weights reflect converted dollar holdings

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68c9bf34f2788324862479387bbd2ebe